### PR TITLE
Replace UITableViewRowAnimation with UITableView.RowAnimation for Swift 4.2

### DIFF
--- a/DifferenceKit.xcodeproj/project.pbxproj
+++ b/DifferenceKit.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
@@ -472,7 +472,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;

--- a/Sources/UIExtensions/UIKitExtension.swift
+++ b/Sources/UIExtensions/UIKitExtension.swift
@@ -17,7 +17,7 @@ public extension UITableView {
     ///              The collection should be set to dataSource of UITableView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
-        with animation: @autoclosure () -> UITableViewRowAnimation,
+        with animation: @autoclosure () -> UITableView.RowAnimation,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
         ) {
@@ -54,12 +54,12 @@ public extension UITableView {
     ///              The collection should be set to dataSource of UITableView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
-        deleteSectionsAnimation: @autoclosure () -> UITableViewRowAnimation,
-        insertSectionsAnimation: @autoclosure () -> UITableViewRowAnimation,
-        reloadSectionsAnimation: @autoclosure () -> UITableViewRowAnimation,
-        deleteRowsAnimation: @autoclosure () -> UITableViewRowAnimation,
-        insertRowsAnimation: @autoclosure () -> UITableViewRowAnimation,
-        reloadRowsAnimation: @autoclosure () -> UITableViewRowAnimation,
+        deleteSectionsAnimation: @autoclosure () -> UITableView.RowAnimation,
+        insertSectionsAnimation: @autoclosure () -> UITableView.RowAnimation,
+        reloadSectionsAnimation: @autoclosure () -> UITableView.RowAnimation,
+        deleteRowsAnimation: @autoclosure () -> UITableView.RowAnimation,
+        insertRowsAnimation: @autoclosure () -> UITableView.RowAnimation,
+        reloadRowsAnimation: @autoclosure () -> UITableView.RowAnimation,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
         ) {


### PR DESCRIPTION
UITableViewRowAnimation is obsolete and has been replaced by UITableView.RowAnimation.

Currently, this is only in beta and should not be merged to master.