### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/undocumented.json
 ## Gems
 .bundle
 vendor/bundle
+
+## Swift Package build
+.build

--- a/LinuxMain.swift
+++ b/LinuxMain.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+import DifferenceKitTests
+
+var tests = [XCTestCaseEntry]()
+tests += DifferenceKitTests.__allTests()
+
+XCTMain(tests)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:4.2
+
+import PackageDescription
+
+let package = Package(
+    name: "DifferenceKit",
+    products: [
+        .library(name: "DifferenceKit", targets: ["DifferenceKit"])
+    ],
+    targets: [
+        .target(
+            name: "DifferenceKit",
+            path: "Sources",
+			exclude: ["Extensions"]
+        ),
+        .testTarget(
+            name: "DifferenceKitTests",
+            dependencies: ["DifferenceKit"],
+			path: "Tests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ end
 There is no UI extension for watchOS.  
 You can use only the algorithm.  
 
+### [Carthage](https://github.com/Carthage/Carthage)
+Add the following to your `Cartfile`:
+```ruby
+github "ra1028/DifferenceKit"
+```
+And run
+```sh
+carthage update
+```
+
 ### [Swift Package Manager](https://swift.org/package-manager/)
 To use DifferenceKit in a project with SPM, add the following to your `Package.swift`:
 ```swift
@@ -331,16 +341,6 @@ let package = Package(
 )
 ```
 The SPM version does not include the UIKit and AppKit extensions.
-
-### [Carthage](https://github.com/Carthage/Carthage)
-Add the following to your `Cartfile`:
-```ruby
-github "ra1028/DifferenceKit"
-```
-And run
-```sh
-carthage update
-```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,26 @@ end
 There is no UI extension for watchOS.  
 You can use only the algorithm.  
 
+### [Swift Package Manager](https://swift.org/package-manager/)
+To use DifferenceKit in a project with SPM, add the following to your `Package.swift`:
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "YourProjectName",
+    products: [
+        .executable(name: "yourexecutable", targets: ["yourexecutable"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ra1028/DifferenceKit.git", from: "0.8.0")
+    ],
+    targets: [
+        .target(name: "yourexecutable", dependencies: ["DifferenceKit"])
+    ]
+)
+```
+The SPM version does not include the UIKit and AppKit extensions.
+
 ### [Carthage](https://github.com/Carthage/Carthage)
 Add the following to your `Cartfile`:
 ```ruby

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+extension AlgorithmTestCase {
+    static let __allTests = [
+        ("testComplicated1", testComplicated1),
+        ("testComplicated10", testComplicated10),
+        ("testComplicated11", testComplicated11),
+        ("testComplicated2", testComplicated2),
+        ("testComplicated3", testComplicated3),
+        ("testComplicated4", testComplicated4),
+        ("testComplicated5", testComplicated5),
+        ("testComplicated6", testComplicated6),
+        ("testComplicated7", testComplicated7),
+        ("testComplicated8", testComplicated8),
+        ("testComplicated9", testComplicated9),
+        ("testDeleted", testDeleted),
+        ("testDuplicated", testDuplicated),
+        ("testDuplicatedElement", testDuplicatedElement),
+        ("testDuplicatedSection", testDuplicatedSection),
+        ("testDuplicatedSectionAndElement", testDuplicatedSectionAndElement),
+        ("testEmptyChangesets", testEmptyChangesets),
+        ("testInserted", testInserted),
+        ("testMixedChanges", testMixedChanges),
+        ("testMixedSectionChanges", testMixedSectionChanges),
+        ("testMoved", testMoved),
+        ("testSameHashValue", testSameHashValue),
+        ("testSectionDeleted", testSectionDeleted),
+        ("testSectionedEmptyChangesets", testSectionedEmptyChangesets),
+        ("testSectionInserted", testSectionInserted),
+        ("testSectionMoved", testSectionMoved),
+        ("testSectionUpdated", testSectionUpdated),
+        ("testUpdated", testUpdated),
+    ]
+}
+
+extension AnyDifferentiableTestCase {
+    static let __allTests = [
+        ("testHashable", testHashable),
+    ]
+}
+
+extension ArraySectionTestCase {
+    static let __allTests = [
+        ("testReinitialize", testReinitialize),
+    ]
+}
+
+extension ChangesetTestCase {
+    static let __allTests = [
+        ("testchangeCount", testchangeCount),
+        ("testEquatable", testEquatable),
+        ("testHasChanges", testHasChanges),
+    ]
+}
+
+extension ContentEquatableTestCase {
+    static let __allTests = [
+        ("testEquatableValue", testEquatableValue),
+        ("testOptionalValue", testOptionalValue),
+    ]
+}
+
+extension ElementPathTestCase {
+    static let __allTests = [
+        ("testHashable", testHashable),
+    ]
+}
+
+extension MeasurementTestCase {
+    static let __allTests = [
+        ("testMeasureAlgorithmForLinearCollection", testMeasureAlgorithmForLinearCollection),
+        ("testMeasureAlgorithmForSectionedCollection", testMeasureAlgorithmForSectionedCollection),
+    ]
+}
+
+extension StagedChangesetTestCase {
+    static let __allTests = [
+        ("testEquatable", testEquatable),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(AlgorithmTestCase.__allTests),
+        testCase(AnyDifferentiableTestCase.__allTests),
+        testCase(ArraySectionTestCase.__allTests),
+        testCase(ChangesetTestCase.__allTests),
+        testCase(ContentEquatableTestCase.__allTests),
+        testCase(ElementPathTestCase.__allTests),
+        testCase(MeasurementTestCase.__allTests),
+        testCase(StagedChangesetTestCase.__allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
This implements support for SPM by including a Package.swift file. It was fairly easy to do since the project already follows the conventions.

I decided to not include the extensions in the package since most people (like myself) probably just want the protocol and algorithm for a command line tool or Swift on the server project. I tested it on a Linux machine and all tests passed.

The files `LinuxMain.swift` and `Tests/XCTestManifests.swift` are auto-generated using the command `swift test --generate-linuxmain`.

I also updated the readme to include information on how to use DifferenceKit with SPM.