### PR TITLE
Implement changes for Swift 4.2 and 5.0 with Xcode 10.2

### DIFF
--- a/Sources/Algorithm.swift
+++ b/Sources/Algorithm.swift
@@ -19,7 +19,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    public init(source: Collection, target: Collection) {
+    init(source: Collection, target: Collection) {
         self.init(source: source, target: target, section: 0)
     }
 
@@ -44,7 +44,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    public init(source: Collection, target: Collection, section: Int) {
+    init(source: Collection, target: Collection, section: Int) {
         let sourceElements = ContiguousArray(source)
         let targetElements = ContiguousArray(target)
 
@@ -151,7 +151,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    public init(source: Collection, target: Collection) {
+    init(source: Collection, target: Collection) {
         typealias Section = Collection.Element
         typealias SectionIdentifier = Collection.Element.DifferenceIdentifier
         typealias Element = Collection.Element.Collection.Element
@@ -326,9 +326,15 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
             fourthStageElements.reserveCapacity(targetElements.count)
 
             for targetElementIndex in targetElements.indices {
+                #if swift(>=5.0)
+                untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
+                    sourceElementTraces[sourceSectionIndex].suffix(from: index).firstIndex { !$0.isTracked }
+                }
+                #else
                 untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
                     sourceElementTraces[sourceSectionIndex].suffix(from: index).index { !$0.isTracked }
                 }
+                #endif
 
                 let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
                 let targetElement = contiguousTargetSections[targetElementPath]
@@ -536,9 +542,15 @@ internal func differentiate<E: Differentiable, I>(
 
     // Record the updates/moves/insertions.
     for targetIndex in target.indices {
+        #if swift(>=5.0)
+        untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
+            sourceTraces.suffix(from: index).firstIndex { !$0.isTracked }
+        }
+        #else
         untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
             sourceTraces.suffix(from: index).index { !$0.isTracked }
         }
+        #endif
 
         if let sourceIndex = targetReferences[targetIndex] {
             sourceTraces[sourceIndex].isTracked = true
@@ -654,13 +666,10 @@ internal final class IndicesReference {
 @usableFromInline
 internal struct TableKey<T: Hashable>: Hashable {
     @usableFromInline
-    internal let hashValue: Int
-    @usableFromInline
     internal let pointer: UnsafePointer<T>
 
     @inlinable
     internal init(pointer: UnsafePointer<T>) {
-        self.hashValue = pointer.pointee.hashValue
         self.pointer = pointer
     }
 
@@ -669,11 +678,15 @@ internal struct TableKey<T: Hashable>: Hashable {
         return lhs.hashValue == rhs.hashValue
             && (lhs.pointer.distance(to: rhs.pointer) == 0 || lhs.pointer.pointee == rhs.pointer.pointee)
     }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(pointer.pointee)
+    }
 }
 
 internal extension MutableCollection where Element: MutableCollection, Index == Int, Element.Index == Int {
     @inlinable
-    internal subscript(path: ElementPath) -> Element.Element {
+    subscript(path: ElementPath) -> Element.Element {
         get { return self[path.section][path.element] }
         set { self[path.section][path.element] = newValue }
     }

--- a/Sources/Algorithm.swift
+++ b/Sources/Algorithm.swift
@@ -326,15 +326,13 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
             fourthStageElements.reserveCapacity(targetElements.count)
 
             for targetElementIndex in targetElements.indices {
-                #if swift(>=5.0)
                 untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
-                    sourceElementTraces[sourceSectionIndex].suffix(from: index).firstIndex { !$0.isTracked }
+                    #if swift(>=5.0)
+                    return sourceElementTraces[sourceSectionIndex].suffix(from: index).firstIndex { !$0.isTracked }
+                    #else
+                    return sourceElementTraces[sourceSectionIndex].suffix(from: index).index { !$0.isTracked }
+                    #endif
                 }
-                #else
-                untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
-                    sourceElementTraces[sourceSectionIndex].suffix(from: index).index { !$0.isTracked }
-                }
-                #endif
 
                 let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
                 let targetElement = contiguousTargetSections[targetElementPath]
@@ -542,15 +540,13 @@ internal func differentiate<E: Differentiable, I>(
 
     // Record the updates/moves/insertions.
     for targetIndex in target.indices {
-        #if swift(>=5.0)
         untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
-            sourceTraces.suffix(from: index).firstIndex { !$0.isTracked }
+            #if swift(>=5.0)
+            return sourceTraces.suffix(from: index).firstIndex { !$0.isTracked }
+            #else
+            return sourceTraces.suffix(from: index).index { !$0.isTracked }
+            #endif
         }
-        #else
-        untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
-            sourceTraces.suffix(from: index).index { !$0.isTracked }
-        }
-        #endif
 
         if let sourceIndex = targetReferences[targetIndex] {
             sourceTraces[sourceIndex].isTracked = true

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -65,7 +65,7 @@ public struct Changeset<Collection: Swift.Collection> {
 public extension Changeset {
     /// The number of section changes.
     @inlinable
-    public var sectionChangeCount: Int {
+    var sectionChangeCount: Int {
         return sectionDeleted.count
             + sectionInserted.count
             + sectionUpdated.count
@@ -74,7 +74,7 @@ public extension Changeset {
 
     /// The number of element changes.
     @inlinable
-    public var elementChangeCount: Int {
+    var elementChangeCount: Int {
         return elementDeleted.count
             + elementInserted.count
             + elementUpdated.count
@@ -83,25 +83,25 @@ public extension Changeset {
 
     /// The number of all changes.
     @inlinable
-    public var changeCount: Int {
+    var changeCount: Int {
         return sectionChangeCount + elementChangeCount
     }
 
     /// A Boolean value indicating whether has section changes.
     @inlinable
-    public var hasSectionChanges: Bool {
+    var hasSectionChanges: Bool {
         return sectionChangeCount > 0
     }
 
     /// A Boolean value indicating whether has element changes.
     @inlinable
-    public var hasElementChanges: Bool {
+    var hasElementChanges: Bool {
         return elementChangeCount > 0
     }
 
     /// A Boolean value indicating whether has changes.
     @inlinable
-    public var hasChanges: Bool {
+    var hasChanges: Bool {
         return changeCount > 0
     }
 }

--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -15,6 +15,23 @@ public extension NSTableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
+    #if swift(>=5.0)
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        with animation: @autoclosure () -> NSTableView.AnimationOptions,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        reload(
+            using: stagedChangeset,
+            deleteRowsAnimation: animation(),
+            insertRowsAnimation: animation(),
+            reloadRowsAnimation: animation(),
+            interrupt: interrupt,
+            setData: setData
+        )
+    }
+    #else
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> NSTableView.AnimationOptions,
@@ -30,6 +47,7 @@ public extension NSTableView {
             setData: setData
         )
     }
+    #endif
 
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///

--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -15,13 +15,14 @@ public extension NSTableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
-    #if swift(>=5.0)
+
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> NSTableView.AnimationOptions,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
         ) {
+        #if swift(>=5.0)
         reload(
             using: stagedChangeset,
             deleteRowsAnimation: animation(),
@@ -30,14 +31,7 @@ public extension NSTableView {
             interrupt: interrupt,
             setData: setData
         )
-    }
-    #else
-    func reload<C>(
-        using stagedChangeset: StagedChangeset<C>,
-        with animation: @autoclosure () -> NSTableView.AnimationOptions,
-        interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
-        ) {
+        #else
         reload(
             using: stagedChangeset,
             deleteRowsAnimation: animation,
@@ -46,8 +40,8 @@ public extension NSTableView {
             interrupt: interrupt,
             setData: setData
         )
+        #endif
     }
-    #endif
 
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -21,6 +21,19 @@ public extension UITableView {
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
         ) {
+        #if swift(>=5.0)
+        reload(
+            using: stagedChangeset,
+            deleteSectionsAnimation: animation(),
+            insertSectionsAnimation: animation(),
+            reloadSectionsAnimation: animation(),
+            deleteRowsAnimation: animation(),
+            insertRowsAnimation: animation(),
+            reloadRowsAnimation: animation(),
+            interrupt: interrupt,
+            setData: setData
+        )
+        #else
         reload(
             using: stagedChangeset,
             deleteSectionsAnimation: animation,
@@ -32,6 +45,7 @@ public extension UITableView {
             interrupt: interrupt,
             setData: setData
         )
+        #endif
     }
 
     /// Applies multiple animated updates in stages using `StagedChangeset`.

--- a/Sources/StagedChangeset.swift
+++ b/Sources/StagedChangeset.swift
@@ -43,6 +43,41 @@ public struct StagedChangeset<Collection: Swift.Collection> {
     }
 }
 
+#if compiler(>=5.0)
+/* Removes MutableCollection conformance as it is redundant. */
+extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection {
+    @inlinable
+    public init() {
+        self.init([])
+    }
+
+    @inlinable
+    public var startIndex: Int {
+        return changesets.startIndex
+    }
+
+    @inlinable
+    public var endIndex: Int {
+        return changesets.endIndex
+    }
+
+    @inlinable
+    public func index(after i: Int) -> Int {
+        return changesets.index(after: i)
+    }
+
+    @inlinable
+    public subscript(position: Int) -> Changeset<Collection> {
+        get { return changesets[position] }
+        set { changesets[position] = newValue }
+    }
+
+    @inlinable
+    public mutating func replaceSubrange<C: Swift.Collection, R: RangeExpression>(_ subrange: R, with newElements: C) where C.Element == Changeset<Collection>, R.Bound == Int {
+        changesets.replaceSubrange(subrange, with: newElements)
+    }
+}
+#else
 extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, MutableCollection {
     @inlinable
     public init() {
@@ -75,6 +110,7 @@ extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, M
         changesets.replaceSubrange(subrange, with: newElements)
     }
 }
+#endif
 
 extension StagedChangeset: Equatable where Collection: Equatable {
     @inlinable

--- a/Sources/StagedChangeset.swift
+++ b/Sources/StagedChangeset.swift
@@ -76,7 +76,7 @@ extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection {
     }
 }
 
-#if compiler(<5.0) && compiler(>=4.0)
+#if !compiler(>=5.0) && compiler(>=4.0)
 extension StagedChangeset: MutableCollection {}
 #endif
 

--- a/Sources/StagedChangeset.swift
+++ b/Sources/StagedChangeset.swift
@@ -43,8 +43,6 @@ public struct StagedChangeset<Collection: Swift.Collection> {
     }
 }
 
-#if compiler(>=5.0)
-/* Removes MutableCollection conformance as it is redundant. */
 extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection {
     @inlinable
     public init() {
@@ -77,39 +75,9 @@ extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection {
         changesets.replaceSubrange(subrange, with: newElements)
     }
 }
-#else
-extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, MutableCollection {
-    @inlinable
-    public init() {
-        self.init([])
-    }
 
-    @inlinable
-    public var startIndex: Int {
-        return changesets.startIndex
-    }
-
-    @inlinable
-    public var endIndex: Int {
-        return changesets.endIndex
-    }
-
-    @inlinable
-    public func index(after i: Int) -> Int {
-        return changesets.index(after: i)
-    }
-
-    @inlinable
-    public subscript(position: Int) -> Changeset<Collection> {
-        get { return changesets[position] }
-        set { changesets[position] = newValue }
-    }
-
-    @inlinable
-    public mutating func replaceSubrange<C: Swift.Collection, R: RangeExpression>(_ subrange: R, with newElements: C) where C.Element == Changeset<Collection>, R.Bound == Int {
-        changesets.replaceSubrange(subrange, with: newElements)
-    }
-}
+#if compiler(<5.0) && compiler(>=4.0)
+extension StagedChangeset: MutableCollection {}
 #endif
 
 extension StagedChangeset: Equatable where Collection: Equatable {


### PR DESCRIPTION
This resolves #54. I also added the Swift 5 changes that are needed as well; those are gated by `#if swift(5.0)`. Other changes should be backwards compatible with `4.2.x` versions of Swift with Xcode 10.