### PR TITLE
Add completion blocks for UIKit extensions

### DIFF
--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -52,6 +52,7 @@ public extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
+    ///   - completion: A closure that gets invoked when all updates have completed.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: @autoclosure () -> RowAnimation,
@@ -61,20 +62,25 @@ public extension UITableView {
         insertRowsAnimation: @autoclosure () -> RowAnimation,
         reloadRowsAnimation: @autoclosure () -> RowAnimation,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C) -> Void,
+        completion: (() -> Void)? = nil
         ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?()
+            return
         }
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?()
+                return
             }
 
-            _performBatchUpdates {
+            _performBatchUpdates({
                 setData(changeset.data)
 
                 if !changeset.sectionDeleted.isEmpty {
@@ -108,17 +114,20 @@ public extension UITableView {
                 for (source, target) in changeset.elementMoved {
                     moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
                 }
-            }
+            }, completion: completion)
         }
     }
 
-    private func _performBatchUpdates(_ updates: () -> Void) {
+    private func _performBatchUpdates(_ updates: () -> Void, completion: (() -> Void)? = nil) {
         if #available(iOS 11.0, tvOS 11.0, *) {
-            performBatchUpdates(updates)
+            performBatchUpdates(updates, completion: { _ in
+                completion?()
+            })
         } else {
             beginUpdates()
             updates()
             endUpdates()
+            completion?()
         }
     }
 }
@@ -136,22 +145,31 @@ public extension UICollectionView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.
+    ///   - completion: A closure that gets invoked when all updates have completed.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
-        setData: (C) -> Void
+        setData: (C) -> Void,
+        completion: (() -> Void)? = nil
         ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?()
+            return
         }
+
+        let dispatchGroup = DispatchGroup()
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?()
+                return
             }
 
+            dispatchGroup.enter()
             performBatchUpdates({
                 setData(changeset.data)
 
@@ -186,7 +204,13 @@ public extension UICollectionView {
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
+            }, completion: { _ in
+                dispatchGroup.leave()
             })
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            completion?()
         }
     }
 }


### PR DESCRIPTION
## What

Adds a `completion` block to the UIKIt reload extensions to get notified when all update operations have finished. 

This is straightforward for UITableViews as there's only a single performBatchUpdate call. Since we fire off multiple `performBatchUpdate` calls for UICollectionViews, we can leverage [`DispatchGroup`](https://developer.apple.com/documentation/dispatch/dispatchgroup) to get notified when all updates have completed.