### PR TITLE
Update license in DifferenceKit.podspec

### DIFF
--- a/DifferenceKit.podspec
+++ b/DifferenceKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
                      The algorithm is optimized based on the Paul Heckel's algorithm.
                      DESC
   spec.source = { :git => 'https://github.com/ra1028/DifferenceKit.git', :tag => spec.version.to_s }
-  spec.license = { :type => 'MIT', :file => 'LICENSE' }
+  spec.license = { :type => 'Apache 2.0', :file => 'LICENSE' }
   spec.requires_arc = true
   spec.default_subspecs = 'Core', 'UIKitExtension'
   spec.swift_version = '4.2'


### PR DESCRIPTION
When the license was changed from MIT the podspec was not updated. This is inconvenient for anyone using the cocoapods-acknowledgements plugin because name of the license and the text of the license do not match