### PR TITLE
Fix for Swift Package Manager in Xcode 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,7 @@ let package = Package(
     targets: [
         .target(
             name: "DifferenceKit",
-            path: "Sources",
-            exclude: ["Extensions"]
+            path: "Sources"
         ),
         .testTarget(
             name: "DifferenceKitTests",


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description

Xcode 11 has Swift Package Manager support and can add dependencies directly to Cocoa projects.
It includes package code based on `Package.swift`, so `Extensions` were left out. I re-added that folder to the package.