### PR TITLE
Expose target with UIKit Extensions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
             path: "Sources",
             exclude: ["Extensions"]
         ),
+        .target(
+            name: "DifferenceKitUIKit",
+            path: "Sources"
+        ),
         .testTarget(
             name: "DifferenceKitTests",
             dependencies: ["DifferenceKit"],


### PR DESCRIPTION
Newer versions of Swift PM have support for creation packages that depend
on UIKit.  This adds a new target so that consumers can get the DifferenceKit
extensions to add to their projects.

## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
