### PR TITLE
Align with Identifiable, Add ContentIdentifiable

### DIFF
--- a/DifferenceKit.xcodeproj/project.pbxproj
+++ b/DifferenceKit.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6B5B40AC211066EA00A931DB /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5B408D211066B300A931DB /* ElementPath.swift */; };
 		6B956B762110B25300DE3D29 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5B4088211066B300A931DB /* UIKitExtension.swift */; };
 		755D649621514ECB0049A3C5 /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D649521514ECB0049A3C5 /* AppKitExtension.swift */; };
+		A9AAED5C235B38DF00995855 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AAED5B235B38DF00995855 /* ContentIdentifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		6B5B409A211066BF00A931DB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6B5B409B211066BF00A931DB /* TestTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTools.swift; sourceTree = "<group>"; };
 		755D649521514ECB0049A3C5 /* AppKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitExtension.swift; sourceTree = "<group>"; };
+		A9AAED5B235B38DF00995855 /* ContentIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentIdentifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 				6B5B408F211066B300A931DB /* Changeset.swift */,
 				6B5B408C211066B300A931DB /* StagedChangeset.swift */,
 				6B444B382163312700AEE32B /* ContentEquatable.swift */,
+				A9AAED5B235B38DF00995855 /* ContentIdentifiable.swift */,
 				6B5B4091211066B300A931DB /* Differentiable.swift */,
 				6B5B408E211066B300A931DB /* DifferentiableSection.swift */,
 				6B5B408B211066B300A931DB /* AnyDifferentiable.swift */,
@@ -301,6 +304,7 @@
 				6B5B40AA211066EA00A931DB /* ArraySection.swift in Sources */,
 				6B5B40A9211066EA00A931DB /* StagedChangeset.swift in Sources */,
 				6B5B40A7211066EA00A931DB /* DifferentiableSection.swift in Sources */,
+				A9AAED5C235B38DF00995855 /* ContentIdentifiable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -68,15 +68,11 @@ Implementation is [here](https://github.com/ra1028/DifferenceKit/blob/master/Sou
 ## Basic Usage
 
 The type of the element that to take diffs must be conform to the `Differentiable` protocol.  
-The `differenceIdentifier`'s type is generic associated type:
+The `id`'s type is generic associated type:
 ```swift
 struct User: Differentiable {
     let id: Int
     let name: String
-
-    var differenceIdentifier: Int {
-        return id
-    }
 
     func isContentEqual(to source: User) -> Bool {
         return name == source.name
@@ -89,7 +85,7 @@ In the case of definition above, `id` uniquely identifies the element and get to
 There are default implementations of `Differentiable` for the types that conforming to `Equatable` or `Hashable`：
 ```swift
 // If `Self` conforming to `Hashable`.
-var differenceIdentifier: Self {
+var id: Self {
     return self
 }
 

--- a/Sources/Algorithm.swift
+++ b/Sources/Algorithm.swift
@@ -153,9 +153,9 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     @inlinable
     init(source: Collection, target: Collection) {
         typealias Section = Collection.Element
-        typealias SectionIdentifier = Collection.Element.DifferenceIdentifier
+        typealias SectionIdentifier = Collection.Element.ID
         typealias Element = Collection.Element.Collection.Element
-        typealias ElementIdentifier = Collection.Element.Collection.Element.DifferenceIdentifier
+        typealias ElementIdentifier = Collection.Element.Collection.Element.ID
 
         let sourceSections = ContiguousArray(source)
         let targetSections = ContiguousArray(target)
@@ -205,7 +205,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
             for sourceElementIndex in contiguousSourceSections[sourceSectionIndex].indices {
                 let sourceElementPath = ElementPath(element: sourceElementIndex, section: sourceSectionIndex)
                 let sourceElement = contiguousSourceSections[sourceElementPath]
-                flattenSourceIdentifiers.append(sourceElement.differenceIdentifier)
+                flattenSourceIdentifiers.append(sourceElement.id)
                 flattenSourceElementPaths.append(sourceElementPath)
             }
         }
@@ -237,7 +237,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
                 let targetElements = contiguousTargetSections[targetSectionIndex]
 
                 for targetElementIndex in targetElements.indices {
-                    var targetIdentifier = targetElements[targetElementIndex].differenceIdentifier
+                    var targetIdentifier = targetElements[targetElementIndex].id
                     let key = TableKey(pointer: &targetIdentifier)
 
                     switch sourceOccurrencesTable[key] {
@@ -456,7 +456,7 @@ internal func diff<E: Differentiable, I>(
     var moved = [(source: I, target: I)]()
 
     var sourceTraces = ContiguousArray<Trace<Int>>()
-    var sourceIdentifiers = ContiguousArray<E.DifferenceIdentifier>()
+    var sourceIdentifiers = ContiguousArray<E.ID>()
     var targetReferences = ContiguousArray<Int?>(repeating: nil, count: target.count)
 
     sourceTraces.reserveCapacity(source.count)
@@ -464,12 +464,12 @@ internal func diff<E: Differentiable, I>(
 
     for sourceElement in source {
         sourceTraces.append(Trace())
-        sourceIdentifiers.append(sourceElement.differenceIdentifier)
+        sourceIdentifiers.append(sourceElement.id)
     }
 
     sourceIdentifiers.withUnsafeBufferPointer { bufferPointer in
         // The pointer and the table key are for optimization.
-        var sourceOccurrencesTable = [TableKey<E.DifferenceIdentifier>: Occurrence](minimumCapacity: source.count)
+        var sourceOccurrencesTable = [TableKey<E.ID>: Occurrence](minimumCapacity: source.count)
 
         // Track indices of elements found in source collection into occurrences table.
         for sourceIndex in sourceIdentifiers.indices {
@@ -491,7 +491,7 @@ internal func diff<E: Differentiable, I>(
 
         // Track target and source indices of the elements having same identifier.
         for targetIndex in target.indices {
-            var targetIdentifier = target[targetIndex].differenceIdentifier
+            var targetIdentifier = target[targetIndex].id
             let key = TableKey(pointer: &targetIdentifier)
 
             switch sourceOccurrencesTable[key] {

--- a/Sources/AnyDifferentiable.swift
+++ b/Sources/AnyDifferentiable.swift
@@ -1,7 +1,7 @@
 /// A type-erased differentiable value.
 ///
 /// The `AnyDifferentiable` type hides the specific underlying types.
-/// Associated type `DifferenceIdentifier` is erased by `AnyHashable`.
+/// Associated type `ID` is erased by `AnyHashable`.
 /// The comparisons of whether has updated is forwards to an underlying differentiable value.
 ///
 /// You can store mixed-type elements in collection that require `Differentiable` conformance by
@@ -31,8 +31,8 @@ public struct AnyDifferentiable: Differentiable {
 
     /// A type-erased identifier value for difference calculation.
     @inlinable
-    public var differenceIdentifier: AnyHashable {
-        return box.differenceIdentifier
+    public var id: AnyHashable {
+        return box.id
     }
 
     @usableFromInline
@@ -74,7 +74,7 @@ extension AnyDifferentiable: CustomDebugStringConvertible {
 @usableFromInline
 internal protocol AnyDifferentiableBox {
     var base: Any { get }
-    var differenceIdentifier: AnyHashable { get }
+    var id: AnyHashable { get }
 
     func isContentEqual(to source: AnyDifferentiableBox) -> Bool
 }
@@ -90,8 +90,8 @@ internal struct DifferentiableBox<Base: Differentiable>: AnyDifferentiableBox {
     }
 
     @inlinable
-    internal var differenceIdentifier: AnyHashable {
-        return baseComponent.differenceIdentifier
+    internal var id: AnyHashable {
+        return baseComponent.id
     }
 
     @inlinable

--- a/Sources/ArraySection.swift
+++ b/Sources/ArraySection.swift
@@ -10,8 +10,8 @@ public struct ArraySection<Model: Differentiable, Element: Differentiable>: Diff
 
     /// An identifier value that of model for difference calculation.
     @inlinable
-    public var differenceIdentifier: Model.DifferenceIdentifier {
-        return model.differenceIdentifier
+    public var id: Model.ID {
+        return model.id
     }
 
     /// Creates a section with the model and the elements.

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -1,6 +1,6 @@
 /// A class of types whose instances hold the value of an entity with stable identity.
 public protocol ContentIdentifiable {
-    ///  A type representing the stable identity of the entity associated with `self`.
+    /// A type representing the stable identity of the entity associated with `self`.
     associatedtype ID: Hashable
 
     /// The stable identity of the entity associated with `self`.

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -1,0 +1,16 @@
+/// A class of types whose instances hold the value of an entity with stable identity.
+public protocol ContentIdentifiable {
+    ///  A type representing the stable identity of the entity associated with `self`.
+    associatedtype ID: Hashable
+
+    /// The stable identity of the entity associated with `self`.
+    var id: ID { get }
+}
+
+public extension ContentIdentifiable where Self: Hashable {
+    /// The `self` value as an identifier for difference calculation.
+    @inlinable
+    var id: Self {
+        return self
+    }
+}

--- a/Sources/Differentiable.swift
+++ b/Sources/Differentiable.swift
@@ -1,16 +1,2 @@
-/// Represents the value that identified for differentiate.
-public protocol Differentiable: ContentEquatable {
-    /// A type representing the identifier.
-    associatedtype DifferenceIdentifier: Hashable
-
-    /// An identifier value for difference calculation.
-    var differenceIdentifier: DifferenceIdentifier { get }
-}
-
-public extension Differentiable where Self: Hashable {
-    /// The `self` value as an identifier for difference calculation.
-    @inlinable
-    var differenceIdentifier: Self {
-        return self
-    }
-}
+/// Represents a type that can be used for identifying and comparing for equality.
+public typealias Differentiable = ContentIdentifiable & ContentEquatable

--- a/Tests/AnyDifferentiableTest.swift
+++ b/Tests/AnyDifferentiableTest.swift
@@ -8,8 +8,8 @@ final class AnyDifferentiableTestCase: XCTestCase {
         let d1 = AnyDifferentiable(base1)
         let d2 = AnyDifferentiable(base1)
 
-        XCTAssertEqual(d1.differenceIdentifier.hashValue, d2.differenceIdentifier.hashValue)
-        XCTAssertEqual(d1.differenceIdentifier, d2.differenceIdentifier)
+        XCTAssertEqual(d1.id.hashValue, d2.id.hashValue)
+        XCTAssertEqual(d1.id, d2.id)
         XCTAssertTrue(d1.isContentEqual(to: d2))
 
         let base2 = M(1, false)
@@ -17,8 +17,8 @@ final class AnyDifferentiableTestCase: XCTestCase {
         let d3 = AnyDifferentiable(base1)
         let d4 = AnyDifferentiable(base2)
 
-        XCTAssertNotEqual(d3.differenceIdentifier.hashValue, d4.differenceIdentifier.hashValue)
-        XCTAssertNotEqual(d3.differenceIdentifier, d4.differenceIdentifier)
+        XCTAssertNotEqual(d3.id.hashValue, d4.id.hashValue)
+        XCTAssertNotEqual(d3.id, d4.id)
         XCTAssertFalse(d3.isContentEqual(to: d4))
 
         let base3 = M(1, true)
@@ -26,8 +26,8 @@ final class AnyDifferentiableTestCase: XCTestCase {
         let d5 = AnyDifferentiable(base2)
         let d6 = AnyDifferentiable(base3)
 
-        XCTAssertEqual(d5.differenceIdentifier.hashValue, d6.differenceIdentifier.hashValue)
-        XCTAssertEqual(d5.differenceIdentifier, d6.differenceIdentifier)
+        XCTAssertEqual(d5.id.hashValue, d6.id.hashValue)
+        XCTAssertEqual(d5.id, d6.id)
         XCTAssertFalse(d5.isContentEqual(to: d6))
     }
 

--- a/Tests/ArraySectionTest.swift
+++ b/Tests/ArraySectionTest.swift
@@ -6,8 +6,8 @@ final class ArraySectionTestCase: XCTestCase {
         let s1 = ArraySection(model: D.a, elements: [0])
         let s2 = ArraySection(model: s1.model, elements: s1.elements)
 
-        XCTAssertEqual(s1.model.differenceIdentifier, s2.model.differenceIdentifier)
-        XCTAssertEqual(s1.model.differenceIdentifier.hashValue, s2.model.differenceIdentifier.hashValue)
+        XCTAssertEqual(s1.model.id, s2.model.id)
+        XCTAssertEqual(s1.model.id.hashValue, s2.model.id.hashValue)
         XCTAssertEqual(s1.elements, s2.elements)
     }
 }

--- a/Tests/TestTools.swift
+++ b/Tests/TestTools.swift
@@ -17,7 +17,7 @@ struct M: Differentiable, Equatable {
         self.b = b
     }
 
-    var differenceIdentifier: Int {
+    var id: Int {
         return i
     }
 }


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
Since the identity component of `Differentiable` is semantically identical to the new [`Identifiable`](https://github.com/apple/swift-evolution/blob/master/proposals/0261-identifiable.md) protocol in Swift 5.1, I think it would be beneficial to align the two APIs.

## Related Issue
#80 

## Motivation and Context
This allows us to easily conform to `Identifiable` as well as `Differentiable` through a single implementation.

## Impact on Existing Code
This will break conformance to `Differentiable` in existing imlpementations, unless implicit conformance through `Hashable`/`Equatable` was used.

## Implementation Details
- Separate Equality (`ContentEquatable`) and Identification (`ContentIdentifiable`) components through the use of protocol composition for `Differentiable`
- Align the API of `ContentIdentifiable` to that of `Identifiable`
