### PR TITLE
Add ContentIdentifiable and use Protocol Composition

### DIFF
--- a/DifferenceKit.xcodeproj/project.pbxproj
+++ b/DifferenceKit.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		6B5B40AC211066EA00A931DB /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5B408D211066B300A931DB /* ElementPath.swift */; };
 		6B956B762110B25300DE3D29 /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5B4088211066B300A931DB /* UIKitExtension.swift */; };
 		755D649621514ECB0049A3C5 /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D649521514ECB0049A3C5 /* AppKitExtension.swift */; };
+		A9AAED5E235EEBBB00995855 /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AAED5D235EEBBB00995855 /* ContentIdentifiable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		6B5B409A211066BF00A931DB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6B5B409B211066BF00A931DB /* TestTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTools.swift; sourceTree = "<group>"; };
 		755D649521514ECB0049A3C5 /* AppKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKitExtension.swift; sourceTree = "<group>"; };
+		A9AAED5D235EEBBB00995855 /* ContentIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentIdentifiable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 				6B5B408F211066B300A931DB /* Changeset.swift */,
 				6B5B408C211066B300A931DB /* StagedChangeset.swift */,
 				6B444B382163312700AEE32B /* ContentEquatable.swift */,
+				A9AAED5D235EEBBB00995855 /* ContentIdentifiable.swift */,
 				6B5B4091211066B300A931DB /* Differentiable.swift */,
 				6B5B408E211066B300A931DB /* DifferentiableSection.swift */,
 				6B5B408B211066B300A931DB /* AnyDifferentiable.swift */,
@@ -301,6 +304,7 @@
 				6B5B40AA211066EA00A931DB /* ArraySection.swift in Sources */,
 				6B5B40A9211066EA00A931DB /* StagedChangeset.swift in Sources */,
 				6B5B40A7211066EA00A931DB /* DifferentiableSection.swift in Sources */,
+				A9AAED5E235EEBBB00995855 /* ContentIdentifiable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -1,5 +1,5 @@
 /// Represents the value that identified for differentiate.
-public protocol ConntentIdentifiable {
+public protocol ContentIdentifiable {
     /// A type representing the identifier.
     associatedtype DifferenceIdentifier: Hashable
 
@@ -7,7 +7,7 @@ public protocol ConntentIdentifiable {
     var differenceIdentifier: DifferenceIdentifier { get }
 }
 
-public extension ConntentIdentifiable where Self: Hashable {
+public extension ContentIdentifiable where Self: Hashable {
     /// The `self` value as an identifier for difference calculation.
     @inlinable
     var differenceIdentifier: Self {

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -1,0 +1,16 @@
+/// Represents the value that identified for differentiate.
+public protocol ConntentIdentifiable {
+    /// A type representing the identifier.
+    associatedtype DifferenceIdentifier: Hashable
+
+    /// An identifier value for difference calculation.
+    var differenceIdentifier: DifferenceIdentifier { get }
+}
+
+public extension ConntentIdentifiable where Self: Hashable {
+    /// The `self` value as an identifier for difference calculation.
+    @inlinable
+    var differenceIdentifier: Self {
+        return self
+    }
+}

--- a/Sources/Differentiable.swift
+++ b/Sources/Differentiable.swift
@@ -1,2 +1,2 @@
 /// Represents a type that can be used for identifying and comparing for equality.
-public typealias Differentiable = ConntentIdentifiable & ContentEquatable
+public typealias Differentiable = ContentIdentifiable & ContentEquatable

--- a/Sources/Differentiable.swift
+++ b/Sources/Differentiable.swift
@@ -1,16 +1,2 @@
-/// Represents the value that identified for differentiate.
-public protocol Differentiable: ContentEquatable {
-    /// A type representing the identifier.
-    associatedtype DifferenceIdentifier: Hashable
-
-    /// An identifier value for difference calculation.
-    var differenceIdentifier: DifferenceIdentifier { get }
-}
-
-public extension Differentiable where Self: Hashable {
-    /// The `self` value as an identifier for difference calculation.
-    @inlinable
-    var differenceIdentifier: Self {
-        return self
-    }
-}
+/// Represents a type that can be used for identifying and comparing for equality.
+public typealias Differentiable = ConntentIdentifiable & ContentEquatable


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
Separate Equality (ContentEquatable) and Identification (ContentIdentifiable) components through the use of protocol composition for Differentiable

## Related Issue
#80 

## Motivation and Context
I believe it's cleaner to have the two protocols not be interdependent.
This allows working with them on a more granular level

## Impact on Existing Code
None