### PR TITLE
Completion Block for UICollectionView and UITableView reload

### DIFF
--- a/DifferenceKit.playground/Sources/TableViewController.swift
+++ b/DifferenceKit.playground/Sources/TableViewController.swift
@@ -10,9 +10,12 @@ public final class TableViewController: UITableViewController {
         get { return data }
         set {
             let changeset = StagedChangeset(source: data, target: newValue)
-            tableView.reload(using: changeset, with: .fade) { data in
+            tableView?.reload(using: changeset, with: .fade, setData: { data in
                 self.data = data
-            }
+                print("Set the data")
+            }, completion: {
+                print("Reloading is complete")
+            })
         }
     }
 

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -73,20 +73,14 @@ public extension UITableView {
             return _reloadData(completion: completion)
         }
 
-        var count = stagedChangeset.count
         let dispatchGroup = DispatchGroup()
-        dispatchGroup.enter()
+        (0..<stagedChangeset.count).forEach { dispatchGroup.enter() }
         dispatchGroup.notify(queue: .main, execute: { completion?() })
-
-        func decrementCountAndCheckIfCompletedReloading() {
-            count -= 1
-            if count == 0 { dispatchGroup.leave() }
-        }
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return _reloadData(completion: { decrementCountAndCheckIfCompletedReloading() })
+                return _reloadData(completion: { dispatchGroup.leave() })
             }
 
             _performBatchUpdates({
@@ -123,7 +117,7 @@ public extension UITableView {
                 for (source, target) in changeset.elementMoved {
                     moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
                 }
-            }, completion: { decrementCountAndCheckIfCompletedReloading() })
+            }, completion: { dispatchGroup.leave() })
         }
     }
 
@@ -174,20 +168,14 @@ public extension UICollectionView {
             return _reloadData(completion: completion)
         }
 
-        var count = stagedChangeset.count
         let dispatchGroup = DispatchGroup()
-        dispatchGroup.enter()
+        (0..<stagedChangeset.count).forEach { dispatchGroup.enter() }
         dispatchGroup.notify(queue: .main, execute: { completion?() })
-
-        func decrementCountAndCheckIfCompletedReloading() {
-            count -= 1
-            if count == 0 { dispatchGroup.leave() }
-        }
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return _reloadData(completion: { decrementCountAndCheckIfCompletedReloading() })
+                return _reloadData(completion: { dispatchGroup.leave() })
             }
 
             performBatchUpdates({
@@ -224,7 +212,7 @@ public extension UICollectionView {
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
-            }, completion: { _ in decrementCountAndCheckIfCompletedReloading() })
+            }, completion: { _ in dispatchGroup.leave() })
         }
     }
 

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -15,6 +15,7 @@ public extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
+    ///   - completion: An optional closure that reports the completion of the reload.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> RowAnimation,
@@ -54,6 +55,7 @@ public extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
+    ///   - completion: An optional closure that reports the completion of the reload.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: @autoclosure () -> RowAnimation,
@@ -150,6 +152,7 @@ public extension UICollectionView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.
+    ///   - completion: An optional closure that reports the completion of the reload.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -72,23 +72,23 @@ public extension UITableView {
             setData(data)
             return _reloadData(completion: completion)
         }
-        
+
         var count = stagedChangeset.count
         let dispatchGroup = DispatchGroup()
         dispatchGroup.enter()
         dispatchGroup.notify(queue: .main, execute: { completion?() })
-        
+
         func decrementCountAndCheckIfCompletedReloading() {
-            count = count - 1
+            count -= 1
             if count == 0 { dispatchGroup.leave() }
         }
-        
+
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
                 return _reloadData(completion: { decrementCountAndCheckIfCompletedReloading() })
             }
-            
+
             _performBatchUpdates({
                 setData(changeset.data)
 
@@ -140,7 +140,7 @@ public extension UITableView {
             CATransaction.commit()
         }
     }
-    
+
     private func _reloadData(completion: (() -> Void)? = nil) {
         CATransaction.begin()
         CATransaction.setCompletionBlock(completion)
@@ -173,14 +173,14 @@ public extension UICollectionView {
             setData(data)
             return _reloadData(completion: completion)
         }
-        
+
         var count = stagedChangeset.count
         let dispatchGroup = DispatchGroup()
         dispatchGroup.enter()
         dispatchGroup.notify(queue: .main, execute: { completion?() })
-        
+
         func decrementCountAndCheckIfCompletedReloading() {
-            count = count - 1
+            count -= 1
             if count == 0 { dispatchGroup.leave() }
         }
 
@@ -227,7 +227,7 @@ public extension UICollectionView {
             }, completion: { _ in decrementCountAndCheckIfCompletedReloading() })
         }
     }
-    
+
     private func _reloadData(completion: (() -> Void)? = nil) {
         CATransaction.begin()
         CATransaction.setCompletionBlock(completion)

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -74,7 +74,7 @@ public extension UITableView {
         }
 
         let dispatchGroup = DispatchGroup()
-        (0..<stagedChangeset.count).forEach { dispatchGroup.enter() }
+        (0..<stagedChangeset.count).forEach { _ in dispatchGroup.enter() }
         dispatchGroup.notify(queue: .main, execute: { completion?() })
 
         for changeset in stagedChangeset {
@@ -169,7 +169,7 @@ public extension UICollectionView {
         }
 
         let dispatchGroup = DispatchGroup()
-        (0..<stagedChangeset.count).forEach { dispatchGroup.enter() }
+        (0..<stagedChangeset.count).forEach { _ in dispatchGroup.enter() }
         dispatchGroup.notify(queue: .main, execute: { completion?() })
 
         for changeset in stagedChangeset {


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  
- [x] Updated Example

## Description
As discussed in https://github.com/ra1028/DiffableDataSources/pull/10 a completion block is needed in `DiffableDataSource` to mirror Apple's APIs as closely as possible. Moreover, having a completion block when Differences are applied might be very handy for client to have.

## Related Issue
https://github.com/ra1028/DiffableDataSources/pull/10

## Motivation and Context
Provides better usage of the API with having a Completion block.

## Impact on Existing Code
APIs will not break as the completion block is `Optional` and defaulted to `nil`