### PR TITLE
Enabling library evolution mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["10.1", "10.2", "11.1"]
+        # xcode_version: ["10.1", "10.2", "11.1"]
+        xcode_version: ["11.1"] # GitHub actions is now unsupported Xcode version 10.1 and 10.2.
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:

--- a/DifferenceKit.xcodeproj/project.pbxproj
+++ b/DifferenceKit.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 			baseConfigurationReference = 6B2DF88A210E39A8004D2D40 /* DifferenceKit.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
@@ -481,6 +482,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -492,6 +494,7 @@
 			baseConfigurationReference = 6B2DF88A210E39A8004D2D40 /* DifferenceKit.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;

--- a/Sources/Algorithm.swift
+++ b/Sources/Algorithm.swift
@@ -586,7 +586,7 @@ internal struct DiffResult<Index> {
     @usableFromInline
     internal let targetReferences: ContiguousArray<Int?>
 
-    @inlinable
+    @usableFromInline
     internal init(
         deleted: [Index] = [],
         inserted: [Index] = [],
@@ -614,8 +614,8 @@ internal struct Trace<Index> {
     @usableFromInline
     internal var isTracked = false
 
-    @inlinable
-    init() {}
+    @usableFromInline
+    internal init() {}
 }
 
 /// The occurrences of element.
@@ -633,7 +633,7 @@ internal final class IndicesReference {
     @usableFromInline
     internal var position = 0
 
-    @inlinable
+    @usableFromInline
     internal init(_ indices: ContiguousArray<Int>) {
         self.indices = indices
     }
@@ -661,7 +661,7 @@ internal struct TableKey<T: Hashable>: Hashable {
     @usableFromInline
     internal let pointer: UnsafePointer<T>
 
-    @inlinable
+    @usableFromInline
     internal init(pointer: UnsafePointer<T>) {
         self.pointeeHashValue = pointer.pointee.hashValue
         self.pointer = pointer

--- a/Sources/AnyDifferentiable.swift
+++ b/Sources/AnyDifferentiable.swift
@@ -42,7 +42,6 @@ public struct AnyDifferentiable: Differentiable {
     ///
     /// - Parameters:
     ///   - base: A differentiable value to wrap.
-    @inlinable
     public init<D: Differentiable>(_ base: D) {
         if let anyDifferentiable = base as? AnyDifferentiable {
             self = anyDifferentiable
@@ -94,7 +93,7 @@ internal struct DifferentiableBox<Base: Differentiable>: AnyDifferentiableBox {
         return baseComponent.differenceIdentifier
     }
 
-    @inlinable
+    @usableFromInline
     internal init(_ base: Base) {
         baseComponent = base
     }

--- a/Sources/ArraySection.swift
+++ b/Sources/ArraySection.swift
@@ -19,7 +19,6 @@ public struct ArraySection<Model: Differentiable, Element: Differentiable>: Diff
     /// - Parameters:
     ///   - model: A differentiable model of section.
     ///   - elements: The collection of element in the section.
-    @inlinable
     public init<C: Collection>(model: Model, elements: C) where C.Element == Element {
         self.model = model
         self.elements = Array(elements)

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -38,7 +38,6 @@ public struct Changeset<Collection: Swift.Collection> {
     ///   - elementInserted: The paths of inserted elements.
     ///   - elementUpdated: The paths of updated elements.
     ///   - elementMoved: The pairs of source and target path of moved elements.
-    @inlinable
     public init(
         data: Collection,
         sectionDeleted: [Int] = [],

--- a/Sources/ElementPath.swift
+++ b/Sources/ElementPath.swift
@@ -12,7 +12,6 @@ public struct ElementPath: Hashable {
     /// - Parameters:
     ///   - element: The element index (or offset).
     ///   - section: The section index (or offset).
-    @inlinable
     public init(element: Int, section: Int) {
         self.element = element
         self.section = section

--- a/Sources/StagedChangeset.swift
+++ b/Sources/StagedChangeset.swift
@@ -37,7 +37,6 @@ public struct StagedChangeset<Collection: Swift.Collection> {
     ///
     /// - Parameters:
     ///   - changesets: The collection of `Changeset`.
-    @inlinable
     public init<C: Swift.Collection>(_ changesets: C) where C.Element == Changeset<Collection> {
         self.changesets = ContiguousArray(changesets)
     }


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Enable library evolution mode by setting `YES` to `BUILD_LIBRARY_FOR_DISTRIBUTION`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ra1028/DifferenceKit/issues/86

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The library evolution mode allows developers using DifferenceKit to use binaries built with older versions of Swift in the newer version by module stability.

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->
N/A
