### PR TITLE
Throw assertion when attempting to inject section changes on AppKit

### DIFF
--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -66,6 +66,9 @@ public extension NSTableView {
                 return reloadData()
             }
 
+            assert(changeset.sectionChangeCount < 1,
+                   "NSTableView group rows are not yet supported, sorry.")
+
             beginUpdates()
             setData(changeset.data)
 
@@ -119,6 +122,9 @@ public extension NSCollectionView {
                 setData(data)
                 return reloadData()
             }
+
+            assert(changeset.sectionChangeCount < 1,
+                   "NSCollectionView sections are not yet supported, sorry.")
 
             animator().performBatchUpdates({
                 setData(changeset.data)


### PR DESCRIPTION
Section changes are not supported yet on AppKit (neither
NSCollectionView nor NSTableView, see issues #93/#94).

## Checklist
- [x] All tests are passed.  
- [-] Added tests.  
- [-] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description

Just added a single assertion to both extensions:
```swift
            assert(changeset.sectionChangeCount < 1,
                   "NSCollectionView sections are not yet supported, sorry.")
```

## Related Issue
- #93 for NSTableView
- #94 for NSCollectionView

## Motivation and Context
Without the assertion, the extensions silently drop changes / do the wrong thing. This way we can at least catch them in debug mode.

## Impact on Existing Code
No impact.

## Screenshots (if appropriate)
![Screenshot 2020-01-20 at 16 02 07](https://user-images.githubusercontent.com/7712892/72736623-55e27f00-3b9e-11ea-9d62-8166126d56b6.png)
