### PR TITLE
Add conditional ContentEquatable conformance to Array

### DIFF
--- a/Sources/ContentEquatable.swift
+++ b/Sources/ContentEquatable.swift
@@ -50,3 +50,19 @@ extension Optional: ContentEquatable where Wrapped: ContentEquatable {
         }
     }
 }
+
+extension Array: ContentEquatable where Element: ContentEquatable {
+    /// Indicate whether the content of `self` is equals to the content of
+    /// the given source value.
+    ///
+    /// - Parameters:
+    ///   - source: A source value to be compared.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `self` is equals
+    ///            to the content of the given source value.
+    @inlinable
+    public func isContentEqual(to source: Array<Element>) -> Bool {
+        return count == source.count
+            && zip(self, source).allSatisfy { $0.isContentEqual(to: $1) }
+    }
+}

--- a/Sources/ContentEquatable.swift
+++ b/Sources/ContentEquatable.swift
@@ -61,7 +61,7 @@ extension Array: ContentEquatable where Element: ContentEquatable {
     /// - Returns: A Boolean value indicating whether the content of `self` is equals
     ///            to the content of the given source value.
     @inlinable
-    public func isContentEqual(to source: Array<Element>) -> Bool {
+    public func isContentEqual(to source: [Element]) -> Bool {
         return count == source.count
             && zip(self, source).allSatisfy { $0.isContentEqual(to: $1) }
     }


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
This adds a conditional `ContentEquatable` conformance to `Array<T>` if `T` conforms to `ContentEquatable`.

## Related Issue
#100: Array<T: ContentEquatable> does not conform to ContentEquatable

## Motivation and Context
This potentially simplifies the implementation of `ContentEquatable` and thus `Differentiable` of a container type, if it contains an array of differentiable items.

Closes #100

## Impact on Existing Code
Existing code should not be affected, but this can make it easier to implement `ContentEquatable` and thus `Differentiable` conformance.

## Screenshots (if appropriate)
