### PR TITLE
Added animation completion handlers for UIKit/AppKit extensions

### DIFF
--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -11,7 +11,7 @@ public extension NSTableView {
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
     ///   - animation: An option to animate the updates.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
@@ -43,7 +43,7 @@ public extension NSTableView {
     ///   - deleteRowsAnimation: An option to animate the row deletion.
     ///   - insertRowsAnimation: An option to animate the row insertion.
     ///   - reloadRowsAnimation: An option to animate the row reload.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
@@ -100,7 +100,7 @@ public extension NSCollectionView {
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSCollectionView.

--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -13,6 +13,8 @@ public extension NSTableView {
     ///   - animation: An option to animate the updates.
     ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - completion: A closure that is called when the animated updates have finished.
+    ///                 The argument is` true` if the animation ran to completion before it stopped or `false` if it did not.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
 
@@ -20,6 +22,7 @@ public extension NSTableView {
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> NSTableView.AnimationOptions,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
+        completion: ((Bool) -> Void)? = nil,
         setData: (C) -> Void
         ) {
         reload(
@@ -28,6 +31,7 @@ public extension NSTableView {
             insertRowsAnimation: animation(),
             reloadRowsAnimation: animation(),
             interrupt: interrupt,
+            completion: completion,
             setData: setData
         )
     }
@@ -45,6 +49,8 @@ public extension NSTableView {
     ///   - reloadRowsAnimation: An option to animate the row reload.
     ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - completion: A closure that is called when the animated updates have finished.
+    ///                 The argument is` true` if the animation ran to completion before it stopped or `false` if it did not.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
     func reload<C>(
@@ -53,17 +59,22 @@ public extension NSTableView {
         insertRowsAnimation: @autoclosure () -> NSTableView.AnimationOptions,
         reloadRowsAnimation: @autoclosure () -> NSTableView.AnimationOptions,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
+        completion: ((Bool) -> Void)? = nil,
         setData: (C) -> Void
         ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?(false)
+            return
         }
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?(false)
+                return
             }
 
             beginUpdates()
@@ -87,6 +98,8 @@ public extension NSTableView {
 
             endUpdates()
         }
+
+        completion?(true)
     }
 }
 
@@ -102,26 +115,41 @@ public extension NSCollectionView {
     ///   - stagedChangeset: A staged set of changes.
     ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - completion: A closure that is called when the animated updates have finished.
+    ///                 The argument is` true` if the animation ran to completion before it stopped or `false` if it did not.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSCollectionView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
+        completion: ((Bool) -> Void)? = nil,
         setData: (C) -> Void
         ) {
         if case .none = window, let data = stagedChangeset.last?.data {
             setData(data)
-            return reloadData()
+            reloadData()
+            completion?(false)
+            return
         }
+
+        let dispatchGroup: DispatchGroup? = completion != nil
+            ? DispatchGroup()
+            : nil
+        let completionHandler: ((Bool) -> Void)? = completion != nil
+            ? { _ in dispatchGroup!.leave() }
+            : nil
 
         for changeset in stagedChangeset {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
                 setData(data)
-                return reloadData()
+                reloadData()
+                completion?(false)
+                return
             }
 
             animator().performBatchUpdates({
                 setData(changeset.data)
+                dispatchGroup?.enter()
 
                 if !changeset.elementDeleted.isEmpty {
                     deleteItems(at: Set(changeset.elementDeleted.map { IndexPath(item: $0.element, section: $0.section) }))
@@ -138,7 +166,10 @@ public extension NSCollectionView {
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
-            })
+            }, completionHandler: completionHandler)
+        }
+        dispatchGroup?.notify(queue: .main) {
+            completion!(true)
         }
     }
 }

--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -11,7 +11,7 @@ public extension UITableView {
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
     ///   - animation: An option to animate the updates.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
@@ -48,7 +48,7 @@ public extension UITableView {
     ///   - deleteRowsAnimation: An option to animate the row deletion.
     ///   - insertRowsAnimation: An option to animate the row insertion.
     ///   - reloadRowsAnimation: An option to animate the row reload.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
@@ -133,7 +133,7 @@ public extension UICollectionView {
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
-    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///   - interrupt: A closure that takes a changeset as its argument and returns `true` if the animated
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.


### PR DESCRIPTION
## Checklist
- [+] All tests are passed.  
- [-] Added tests.  
- [+] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [+] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
This is a great library, but one thing is missing: completion handler in the .reload method, causing crashes if reloadData/second .reload call is made during the animations, so I've added it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
