### PR TITLE
ContentIdentifiable subscript on Any MutableCollection

### DIFF
--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -40,7 +40,7 @@ public extension MutableCollection where Element: ContentIdentifiable {
     ///
     /// - Complexity: O(1)
     @inlinable
-    subscript(id identifier: Element.DifferenceIdentifier) -> Optional<Element> {
+    subscript(id identifier: Element.DifferenceIdentifier) -> Element? {
         set {
             guard
                 let index = firstIndex(where: { $0.differenceIdentifier == identifier }),

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -40,7 +40,7 @@ public extension MutableCollection where Element: ContentIdentifiable {
     ///
     /// - Complexity: O(1)
     @inlinable
-    subscript(id identifier: Element.DifferenceIdentifier) -> Element? {
+    subscript(id identifier: Element.DifferenceIdentifier) -> Optional<Element> {
         set {
             guard
                 let index = firstIndex(where: { $0.differenceIdentifier == identifier }),

--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -14,3 +14,45 @@ public extension ContentIdentifiable where Self: Hashable {
         return self
     }
 }
+
+public extension MutableCollection where Element: ContentIdentifiable {
+    /// Accesses and set the element on Collection with spesific `DifferenceIdentifier` identifier.
+    ///
+    /// - Note: If the element doesn't exist, the operation will be cancelled.
+    ///
+    /// For example, you can replace an element of an array by using its
+    /// subscript.
+    ///
+    ///     struct Counter {
+    ///         let differenceIdentifier: String
+    ///         let count: Int
+    ///     }
+    ///
+    ///     var counters = [
+    ///         Counter(differenceIdentifier: "first", count: 0),
+    ///         Counter(differenceIdentifier: "second", count: 1)
+    ///     ]
+    ///     counters[id: "first"]?.count = 100
+    ///     print(counters[id: "first"])
+    ///     // Prints "Counter(differenceIdentifier: "first", count: 100)"
+    ///
+    /// - Parameter id: The identifier of the `ContentIdentifiable`
+    ///
+    /// - Complexity: O(1)
+    @inlinable
+    subscript(id identifier: Element.DifferenceIdentifier) -> Element? {
+        set {
+            guard
+                let index = firstIndex(where: { $0.differenceIdentifier == identifier }),
+                let newValue = newValue
+            else {
+                return
+            }
+
+            self[index] = newValue
+        }
+        get {
+            first(where: { $0.differenceIdentifier == identifier })
+        }
+    }
+}

--- a/Tests/DifferenceIdentifierSubscriptTests.swift
+++ b/Tests/DifferenceIdentifierSubscriptTests.swift
@@ -6,7 +6,7 @@ final class DifferenceIdentifierSubscriptTests: XCTestCase {
         let differenceIdentifier: String
         var count: Int
     }
-    
+
     func testSubscriptSetterExist() {
         var d1 = [
             Counter(differenceIdentifier: "first", count: 0),
@@ -18,11 +18,11 @@ final class DifferenceIdentifierSubscriptTests: XCTestCase {
             Counter(differenceIdentifier: "second", count: 100),
             Counter(differenceIdentifier: "third", count: 0)
         ]
-        
+
         d1[id: "second"]?.count = 100
         XCTAssertEqual(d1, d2)
     }
-    
+
     func testSubscriptSetterNotExist() {
         var d1 = [
             Counter(differenceIdentifier: "first", count: 0),
@@ -34,28 +34,28 @@ final class DifferenceIdentifierSubscriptTests: XCTestCase {
             Counter(differenceIdentifier: "second", count: 0),
             Counter(differenceIdentifier: "third", count: 0)
         ]
-        
+
         d1[id: "forth"]?.count = 100
         XCTAssertEqual(d1, d2)
     }
-    
+
     func testSubscriptGetterExist() {
         let d1 = [
             Counter(differenceIdentifier: "first", count: 100),
             Counter(differenceIdentifier: "second", count: 0),
             Counter(differenceIdentifier: "third", count: 0)
         ]
-        
+
         XCTAssertEqual(d1[id: "first"]?.count, 100)
     }
-    
+
     func testSubscriptGetterNotExist() {
         let d1 = [
             Counter(differenceIdentifier: "first", count: 0),
             Counter(differenceIdentifier: "second", count: 0),
             Counter(differenceIdentifier: "third", count: 0)
         ]
-        
+
         XCTAssertEqual(d1[id: "forth"], nil)
     }
 }

--- a/Tests/DifferenceIdentifierSubscriptTests.swift
+++ b/Tests/DifferenceIdentifierSubscriptTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import DifferenceKit
+
+final class DifferenceIdentifierSubscriptTests: XCTestCase {
+    private struct Counter: ContentIdentifiable, Equatable {
+        let differenceIdentifier: String
+        var count: Int
+    }
+    
+    func testSubscriptSetterExist() {
+        var d1 = [
+            Counter(differenceIdentifier: "first", count: 0),
+            Counter(differenceIdentifier: "second", count: 0),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        let d2 = [
+            Counter(differenceIdentifier: "first", count: 0),
+            Counter(differenceIdentifier: "second", count: 100),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        
+        d1[id: "second"]?.count = 100
+        XCTAssertEqual(d1, d2)
+    }
+    
+    func testSubscriptSetterNotExist() {
+        var d1 = [
+            Counter(differenceIdentifier: "first", count: 0),
+            Counter(differenceIdentifier: "second", count: 0),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        let d2 = [
+            Counter(differenceIdentifier: "first", count: 0),
+            Counter(differenceIdentifier: "second", count: 0),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        
+        d1[id: "forth"]?.count = 100
+        XCTAssertEqual(d1, d2)
+    }
+    
+    func testSubscriptGetterExist() {
+        let d1 = [
+            Counter(differenceIdentifier: "first", count: 100),
+            Counter(differenceIdentifier: "second", count: 0),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        
+        XCTAssertEqual(d1[id: "first"]?.count, 100)
+    }
+    
+    func testSubscriptGetterNotExist() {
+        let d1 = [
+            Counter(differenceIdentifier: "first", count: 0),
+            Counter(differenceIdentifier: "second", count: 0),
+            Counter(differenceIdentifier: "third", count: 0)
+        ]
+        
+        XCTAssertEqual(d1[id: "forth"], nil)
+    }
+}


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [x] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
Add Ability to Any Type that conform `ContentIdentifiable` to have subscript with differenceIdentifier.

Example

```swift
struct Counter {
   let differenceIdentifier: String
   let count: Int
}
     
var counters = [
     Counter(differenceIdentifier: "first", count: 0),
     Counter(differenceIdentifier: "second", count: 1)
 ]
 counters[id: "first"]?.count = 100
 print(counters[id: "first"])
 // Prints "Counter(differenceIdentifier: "first", count: 100)"
```
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
previously handling mutating and accessing value from collection that being used for `DifferenceKit` will require the user to access it with default subscript.

on case where index is irrelevant(random access collection), we need to save the `differenceIdentifier ` as our source to access the value. this will add boiler plate to search index where `differenceIdentifier ` exist and access it with default subscript.

with this subscript, devs can only depend on `differenceIdentifier` as only the source of truth to mutate and access the collection.

## Impact on Existing Code
No Impact on Existing Code

## Screenshots (if appropriate)
