### PR TITLE
Fix the default implementation of Differentiable for Hashable

### DIFF
--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -10,7 +10,7 @@ public protocol ContentIdentifiable {
 public extension ContentIdentifiable where Self: Hashable {
     /// The `self` value as an identifier for difference calculation.
     @inlinable
-    var differenceIdentifier: Self {
-        return self
+    var differenceIdentifier: Int {
+        return hashValue
     }
 }

--- a/Tests/AlgorithmTest.swift
+++ b/Tests/AlgorithmTest.swift
@@ -245,14 +245,16 @@ extension AlgorithmTestCase {
 
     func testSameHashValue() {
         struct A: Hashable, Differentiable {
-            let actualValue: Int
+            let id: Int
+            let actualValue: String
 
-            init(_ actualValue: Int) {
+            init(_ id: Int, _ actualValue: String) {
+                self.id = id
                 self.actualValue = actualValue
             }
 
             func hash(into hasher: inout Hasher) {
-                hasher.combine(0)
+                hasher.combine(id)
             }
 
             func isContentEqual(to source: A) -> Bool {
@@ -262,21 +264,25 @@ extension AlgorithmTestCase {
 
         let section = 0
 
-        let source = [A(0), A(1)]
-        let target = [A(0), A(2)]
-
+        let source = [A(0, "a"), A(1, "b"), A(2, "c")]
+        let target = [A(0, "a"), A(1, "c"), A(3, "c")]
+        
         XCTAssertExactDifferences(
             source: source,
             target: target,
             section: section,
             expected: [
                 Changeset(
-                    data: [A(0)],
-                    elementDeleted: [ElementPath(element: 1, section: section)]
+                    data: [A(0, "a"), A(1, "c"), A(2, "c")],
+                    elementUpdated: [ElementPath(element: 1, section: 0)]
+                ),
+                Changeset(
+                    data: [A(0, "a"), A(1, "c")],
+                    elementDeleted: [ElementPath(element: 2, section: 0)]
                 ),
                 Changeset(
                     data: target,
-                    elementInserted: [ElementPath(element: 1, section: section)]
+                    elementInserted: [ElementPath(element: 2, section: 0)]
                 )
             ]
         )


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
The default implementation of Differentiabe for Hashable has a `differenceIdentifier` property. The implementation of this propeprty now return `hashValue` instead of `self`.

## Related Issue
```swift
// Model
struct ElementModel: Hashable, Differentiable {
    var id: Int
    var title: String
    var value: String

    func hash(into hasher: inout Hasher) {
        hasher.combine(id)
    }
}

// Changeset
let list1 = [ElementModel(id: 1, title: "color", value: "red")]
let list2 = [ElementModel(id: 1, title: "color", value: "blue")]

let changeset = StagedChangeset(source: list1, target: list2)
changeset.forEach { print($0) } // two stage: `delete` -> `insert`
```

The above code produces a `delete -> insert` change, however, it should be a `update` change.

#114: Unexpected behavior when using the default implementations of `Differentiable` for `Hashable`

## Motivation and Context

Close #114 

## Impact on Existing Code
If the existing code rely on the default implementation of Differentiable for Hashable, the reload behavior may changes. Some `delete -> insert` changes will become `update` changes.
