### PR TITLE
Add Apple Silicon architecture for macOS

### DIFF
--- a/DifferenceKit.xcodeproj/project.pbxproj
+++ b/DifferenceKit.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				"VALID_ARCHS[sdk=macosx*]" = "i386 x86_64 arm64";
 			};
 			name = Debug;
 		};
@@ -516,6 +517,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				"VALID_ARCHS[sdk=macosx*]" = "i386 x86_64 arm64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
Apple will release the the architecture Apple Silicon. To make it work with `DifferenceKit`, we need to add `arm64` to the valid architectures of macOS builds.

## Related Issue
#118 

## Motivation and Context
It allows us to use DifferenceKit on Apple Silicon Mac.

## Impact on Existing Code
Nothing.