### PR TITLE
Update GitHub Actions macOS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,11 @@ jobs:
 
   macOS:
     name: Test on macOS
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     strategy:
       fail-fast: false
       matrix:
-        # xcode_version: ["10.1", "10.2", "11.1"]
-        xcode_version: ["11.1"] # GitHub actions is now unsupported Xcode version 10.1 and 10.2.
+        xcode_version: ["11.7", "12.4"] # GitHub actions is now unsupported Xcode version 10.x.
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
- Update GitHub Actions macOS version to current non preview, https://github.com/actions/virtual-environments
- Update GitHub Actions Xcode versions to current 11.x and 12.x since 10.x does not work, https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
GitHub Actions CI is currently failing for macOS builds

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
