### PR TITLE
ARM64 architecture for Apple Silicon support

### DIFF
--- a/XCConfigs/DifferenceKit.xcconfig
+++ b/XCConfigs/DifferenceKit.xcconfig
@@ -6,13 +6,13 @@ WATCHOS_DEPLOYMENT_TARGET = 2.0
 SDKROOT = 
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3,4
-VALID_ARCHS[sdk=macosx*] = i386 x86_64
+VALID_ARCHS[sdk=macosx*] = arm64 i386 x86_64
 VALID_ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*] = i386 x86_64
+VALID_ARCHS[sdk=iphonesimulator*] = arm64 i386 x86_64
 VALID_ARCHS[sdk=appletv*] = arm64
-VALID_ARCHS[sdk=appletvsimulator*] = x86_64
+VALID_ARCHS[sdk=appletvsimulator*] = arm64 x86_64
 VALID_ARCHS[sdk=watchos*] = armv7k
-VALID_ARCHS[sdk=watchsimulator*] = i386
+VALID_ARCHS[sdk=watchsimulator*] = arm64 i386
 
 CODE_SIGN_IDENTITY =
 CODE_SIGN_STYLE = Manual


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Enables native ARM64 builds on Apple Silicon for macOS and iOS, tvOS and watchOS simulator.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/ra1028/DifferenceKit/issues/118

https://github.com/ra1028/DifferenceKit/pull/119 - did not update the correct file and hasn't been updated in a long while

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for native ARM64 builds on Apple Silicon, currently M1 based MacBooks and Mac Mini

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
