### PR TITLE
Improvements on UIKit extension to let reload only visible cells

### DIFF
--- a/DifferenceKit.podspec
+++ b/DifferenceKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'DifferenceKit'
-  spec.version  = '1.1.5'
+  spec.version  = '1.1.5.1'
   spec.author = { 'ra1028' => 'r.fe51028.r@gmail.com' }
   spec.homepage = 'https://github.com/ra1028/DifferenceKit'
   spec.documentation_url = 'https://ra1028.github.io/DifferenceKit'


### PR DESCRIPTION
## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
