### PR TITLE
Enable view-based NSTableViews to reload entire rows

### DIFF
--- a/Sources/Extensions/AppKitExtension.swift
+++ b/Sources/Extensions/AppKitExtension.swift
@@ -78,7 +78,7 @@ public extension NSTableView {
             }
 
             if !changeset.elementUpdated.isEmpty {
-                reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }), columnIndexes: IndexSet(changeset.elementUpdated.map { $0.section }))
+                reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }), columnIndexes: IndexSet(0..<tableColumns.count))
             }
 
             for (source, target) in changeset.elementMoved {


### PR DESCRIPTION
## Checklist
- [X] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [X] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
When an `NSTableView` has view-based cells (e.g. `NSTableViewDelegate`'s `tableView(_:viewFor:row:)` is implemented, rather than just `NSTableViewDataSource`'s `tableView(_:objectValueFor:row)`), its behaviour when `reloadData(forRowIndexes:columnIndexes)` is called changes.

When cell values are only derived from `tableView(_:objectValueFor:row)`, a reload call with any set of `columnIndexes` will lead to the whole row being refreshed. When the delegate method above is implemented, *only the columns of that row directly addressed by the `columnIndexes` argument are reloaded*.

The current code in the AppKit extension *always passes* a `columnIndexes` argument of `[0]`[^1], which therefore only updates the 0th column's cell in any row to which the reload is applied.

My change explicitly adds all valid column indexes to the reloadData call, so that an entire row is refreshed when its associated data element is updated.

[^1]: or more accurately of the element's `section` value, which seems to be an oversight.

## Related Issue
I can raise one with the above observations if it's deemed necessary.

## Motivation and Context
I was motivated by the fact that my NSTableView wouldn't properly refresh. Apologies for not adding documentation or tests but this particular extension lacks these in the first place.

## Impact on Existing Code
I can see no negative impact on existing code, and no risk to the core algorithm since my changes are limited to the AppKit extension.

## Screenshots (if appropriate)
