### PR TITLE
UITableView extension: Completion block for changesets

### DIFF
--- a/Sources/Extensions/UIKitExtension.swift
+++ b/Sources/Extensions/UIKitExtension.swift
@@ -72,6 +72,7 @@ public extension UITableView {
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
     @available(iOS 11.0, tvOS 11.0, *)
+    // swiftlint:disable:next function_parameter_count
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: @autoclosure () -> RowAnimation,
@@ -174,6 +175,7 @@ public extension UITableView {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
     private func _reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: () -> RowAnimation,
@@ -237,14 +239,14 @@ public extension UITableView {
                         moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
                     }
                 },
-                completion: changesetCompleted.flatMap { completion -> ((Bool)->Void) in
+                completion: changesetCompleted.flatMap { completion -> ((Bool) -> Void) in
                     return { finished in completion(changeset, finished ? .completed : .interrupted) }
                 }
             )
         }
     }
 
-    private func _performBatch(updates: () -> Void, completion: ((Bool)->Void)?) {
+    private func _performBatch(updates: () -> Void, completion: ((Bool) -> Void)?) {
         if #available(iOS 11.0, tvOS 11.0, *) {
             performBatchUpdates(updates, completion: completion)
         }


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [x] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
This Pull Request introduces previously discussed (and rejected) proposal for addition of completion handlers. The PR does so for UITableView only. The API introduced by this PR is not simple "passing of a closure to the UIKit API." Instead, the API is designed to provide better information about how the changes were handled.

## Related Issue
https://github.com/ra1028/DifferenceKit/pull/120
https://github.com/ra1028/DifferenceKit/issues/7

## Motivation and Context
I have read the rationale behind rejection. I do think, that this change would simplify the usage of DifferenceKit. 
If this PR is not accepted, I would strongly suggest to put the "workaround" from #7 directly into the Xcode markup documentation for related methods.

## Impact on Existing Code
API changes additive, ambiguity should not be an issue due to overloading instead of optional parameters. 

