### PR TITLE
Add Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 
@@ -13,7 +13,8 @@ let package = Package(
     targets: [
         .target(
             name: "DifferenceKit",
-            path: "Sources"
+            path: "Sources",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .testTarget(
             name: "DifferenceKitTests",

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Checklist
- [x] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [x] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->
Add `PrivacyInfo.xcprivacy` file.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
WWDC 23 introduce Privacy Manifest: https://developer.apple.com/videos/play/wwdc2023/10060/
It will be required on App Store since this Spring.

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
